### PR TITLE
Fixed MCP23016 register write function

### DIFF
--- a/modules/mcp23016.c
+++ b/modules/mcp23016.c
@@ -78,25 +78,14 @@ static uint8_t mcp23016_write_reg (uint8_t reg, uint8_t data) {
 
     uint8_t i2c_addr;
     uint8_t i2c_id;
-    uint8_t rx_len = 0, tx_len = 0;
-    uint8_t read[2] = {0};
-    uint8_t cmd_data[3];
-
-    if( i2c_take_by_chipid( CHIP_ID_MCP23016, &i2c_addr, &i2c_id, (TickType_t) 10) ) {
-        rx_len = xI2CMasterWriteRead(i2c_id, i2c_addr, reg, read, 2);
-        i2c_give(i2c_id);
-    }
-
-    if (!rx_len) {
-    	return 0;
-    }
+    uint8_t tx_len = 0;
+    uint8_t cmd_data[2];
 
     cmd_data[0] = reg;
     cmd_data[1] = data;
-    cmd_data[2] = read[1];
 
     if( i2c_take_by_chipid( CHIP_ID_MCP23016, &i2c_addr, &i2c_id, (TickType_t) 10) ) {
-        tx_len = xI2CMasterWrite(i2c_id, i2c_addr, cmd_data, sizeof(cmd_data));
+        tx_len = xI2CMasterWrite(i2c_id, i2c_addr, cmd_data, 2);
         i2c_give(i2c_id);
     }
 

--- a/modules/mcp23016.c
+++ b/modules/mcp23016.c
@@ -85,7 +85,7 @@ static uint8_t mcp23016_write_reg (uint8_t reg, uint8_t data) {
     cmd_data[1] = data;
 
     if( i2c_take_by_chipid( CHIP_ID_MCP23016, &i2c_addr, &i2c_id, (TickType_t) 10) ) {
-        tx_len = xI2CMasterWrite(i2c_id, i2c_addr, cmd_data, 2);
+        tx_len = xI2CMasterWrite(i2c_id, i2c_addr, cmd_data, sizeof(cmd_data));
         i2c_give(i2c_id);
     }
 


### PR DESCRIPTION
`mcp23016_write_reg` was first reading 2 registers and than writing them back with one changed. Problem is that writing operation is done instantly after reading and MCP23016 seems to need some time to process stuff:
![image](https://user-images.githubusercontent.com/9166701/118967905-8f322700-b96b-11eb-9967-8b750807eb86.png)
Removing extra read operations seems to fix #111 (guess when MCP is hot it gets sluggish). However, this should be explicitly taken into account when multiple operations are executed on the MCP chip. I will make a separate issue to address that.