### PR TITLE
Ensure flash integrity before updating image

### DIFF
--- a/modules/hpm.c
+++ b/modules/hpm.c
@@ -39,6 +39,9 @@ static uint8_t last_cmd_cc;
 /*Current component under upgrade */
 static uint8_t active_id;
 
+/* Variable used to monitor HPM upload fw block command's block number */
+static uint8_t expected_block_n;
+
 /* IPMC Capabilities */
 t_ipmc_capabilities ipmc_cap = {
     .flags = { .upgrade_undesirable = 0,
@@ -210,6 +213,8 @@ IPMI_HANDLER(ipmi_picmg_initiate_upgrade_action, NETFN_GRPEXT, IPMI_PICMG_CMD_HP
     uint8_t comp_id = req->data[1];
     uint8_t upgrade_action = req->data[2];
 
+    expected_block_n = 0x00;
+
     rsp->completion_code = IPMI_CC_UNSPECIFIED_ERROR;
 
     if (comp_id > 7) {
@@ -294,8 +299,6 @@ IPMI_HANDLER(ipmi_picmg_upload_firmware_block, NETFN_GRPEXT, IPMI_PICMG_CMD_HPM_
     uint8_t len = rsp->data_len = 0;
     uint8_t block_data[HPM_BLOCK_SIZE];
     uint8_t block_sz = req->data_len-2;
-
-    static uint8_t expected_block_n = 0x00;
 
     if (active_id > 7) {
         /* Component ID out of range */

--- a/port/ucontroller/nxp/lpc17xx/lpc17_hpm.c
+++ b/port/ucontroller/nxp/lpc17xx/lpc17_hpm.c
@@ -97,12 +97,11 @@ uint8_t ipmc_hpm_prepare_comp( void )
     }
 
     /* Checks flash update region integrity */
-    for(uint32_t *ptr = (uint32_t *)update_start_addr; ptr <= update_end_addr; ptr++) {
+    for(const uint32_t *ptr = update_start_addr; ptr <= update_end_addr; ptr++) {
 	if(*ptr != 0xFFFFFFFF) {
-            const uint32_t update_start_sec = get_sector_number(update_start_addr);
-            const uint32_t update_end_sec = get_sector_number(update_end_addr);
+            const uint32_t sec = get_sector_number(ptr);
 
-            /* Erases flash update region sectors */
+            /* Erases flash update region sector */
             /*
              * This procedure locks the flash, preventing code execution
              * until it finishes. This can take tens of ms for multiple
@@ -112,8 +111,9 @@ uint8_t ipmc_hpm_prepare_comp( void )
              * For LPC1768 devices it would cause the HPM update to fail
              * as it wouldn't answer the ipmi request in time.
              */
-            ret = ipmc_erase_sector(update_start_sec, update_end_sec);
-            break;
+            ret = ipmc_erase_sector(sec, sec);
+
+            if(ret != IPMI_CC_OK)	break;
 	}
     }
 

--- a/port/ucontroller/nxp/lpc17xx/lpc17_hpm.c
+++ b/port/ucontroller/nxp/lpc17xx/lpc17_hpm.c
@@ -90,22 +90,34 @@ uint8_t ipmc_hpm_prepare_comp( void )
     ipmc_page_byte_index = 0;
     ipmc_page_addr = 0;
 
+    uint8_t ret = IPMI_CC_OK;
+
     for(uint32_t i=0; i<(sizeof(ipmc_page)/sizeof(uint32_t)); i++) {
         ipmc_page[i] = 0xFFFFFFFF;
     }
 
-    /*
-     * Assumes that the bootloader has erased the flash update
-     * area. Erasing it here will lock the flash, preventing code
-     * execution until it finishes. This can take tens of ms for
-     * multiple sector erases, and for all this time no interrupt
-     * exceptions can be served.
-     *
-     * For LPC1768 devices it would cause the HPM update to fail as it
-     * wouldn't answer the ipmi request in time.
-     */
+    /* Checks flash update region integrity */
+    for(uint32_t *ptr = (uint32_t *)update_start_addr; ptr <= update_end_addr; ptr++) {
+	if(*ptr != 0xFFFFFFFF) {
+            const uint32_t update_start_sec = get_sector_number(update_start_addr);
+            const uint32_t update_end_sec = get_sector_number(update_end_addr);
 
-    return IPMI_CC_OK;
+            /* Erases flash update region sectors */
+            /*
+             * This procedure locks the flash, preventing code execution
+	     * until it finishes. This can take tens of ms for multiple
+	     * sector erases, and for all this time no interrupt
+             * exceptions can be served.
+             *
+             * For LPC1768 devices it would cause the HPM update to fail
+	     * as it wouldn't answer the ipmi request in time.
+             */
+            ret = ipmc_erase_sector(update_start_sec, update_end_sec);
+            break;
+	}
+    }
+
+    return ret;
 }
 
 uint8_t ipmc_hpm_upload_block( uint8_t * block, uint16_t size )

--- a/port/ucontroller/nxp/lpc17xx/lpc17_hpm.c
+++ b/port/ucontroller/nxp/lpc17xx/lpc17_hpm.c
@@ -105,12 +105,12 @@ uint8_t ipmc_hpm_prepare_comp( void )
             /* Erases flash update region sectors */
             /*
              * This procedure locks the flash, preventing code execution
-	     * until it finishes. This can take tens of ms for multiple
-	     * sector erases, and for all this time no interrupt
+             * until it finishes. This can take tens of ms for multiple
+             * sector erases, and for all this time no interrupt
              * exceptions can be served.
              *
              * For LPC1768 devices it would cause the HPM update to fail
-	     * as it wouldn't answer the ipmi request in time.
+             * as it wouldn't answer the ipmi request in time.
              */
             ret = ipmc_erase_sector(update_start_sec, update_end_sec);
             break;


### PR DESCRIPTION
openMMC was relying on bootloader to erase flash update region. However,
if subsequent firmware updates happen without activation between them,
the final stored image will almost always be corrupted.
This commit adds integrity checking and, if needed, the application
itself erases the flash update region.

NOTE: This might cause HPM update to fail at the first as flash
erasing procedure prevents ipmi request answering in time. A second
attempt will succeed.

Fixes #121.