### PR TITLE
Update common and linker flags in toolchain definition

### DIFF
--- a/toolchain/toolchain-arm-none-eabi.cmake
+++ b/toolchain/toolchain-arm-none-eabi.cmake
@@ -26,7 +26,7 @@ set( CMAKE_OBJCOPY ${TC_PATH}${CROSS_COMPILE}objcopy
 set( CMAKE_OBJDUMP ${TC_PATH}${CROSS_COMPILE}objdump
     CACHE FILEPATH "The toolchain objdump command " FORCE )
 
-set(COMMON_FLAGS "-fno-common -fno-builtin -ffunction-sections -fdata-sections -fno-strict-aliasing -fmessage-length=0")
+set(COMMON_FLAGS "-fno-common -fno-builtin-printf -ffunction-sections -fdata-sections -fno-strict-aliasing -fmessage-length=0")
 set(CMAKE_C_FLAGS "${COMMON_FLAGS} -std=gnu99")
 set(CMAKE_CXX_FLAGS "${COMMON_FLAGS} -std=gnu++0x")
 set(CMAKE_EXE_LINKER_FLAGS "-Wl,--gc-sections,--undefined=uxTopUsedPriority --specs=nosys.specs -nostdlib -static -nostartfiles")

--- a/toolchain/toolchain-arm-none-eabi.cmake
+++ b/toolchain/toolchain-arm-none-eabi.cmake
@@ -29,4 +29,4 @@ set( CMAKE_OBJDUMP ${TC_PATH}${CROSS_COMPILE}objdump
 set(COMMON_FLAGS "-fno-common -fno-builtin-printf -ffunction-sections -fdata-sections -fno-strict-aliasing -fmessage-length=0")
 set(CMAKE_C_FLAGS "${COMMON_FLAGS} -std=gnu99")
 set(CMAKE_CXX_FLAGS "${COMMON_FLAGS} -std=gnu++0x")
-set(CMAKE_EXE_LINKER_FLAGS "-Wl,--gc-sections,--undefined=uxTopUsedPriority --specs=nosys.specs -nostdlib -static -nostartfiles")
+set(CMAKE_EXE_LINKER_FLAGS "-Wl,--gc-sections,--undefined=uxTopUsedPriority --specs=nano.specs -nostartfiles")


### PR DESCRIPTION
I feel like all of `COMMON_FLAGS`, seeing as the flags aren't platform specific and talk about overall program behavior for us, should be in some other common file, whenever we get around to re-organizing the repo.