### PR TITLE
Fix size checks

### DIFF
--- a/modules/fru.c
+++ b/modules/fru.c
@@ -286,7 +286,8 @@ IPMI_HANDLER(ipmi_storage_read_fru_data_cmd, NETFN_STORAGE, IPMI_READ_FRU_DATA_C
     /* Count byte on the request is "1" based */
     uint8_t count = req->data[3];
 
-    if ( (count-1) > IPMI_MSG_MAX_LENGTH ) {
+    /* Consider header, count, data and checksum */
+    if ( (count + IPMB_RESP_HEADER_LENGTH + 2) > IPMI_MSG_MAX_LENGTH ) {
         rsp->completion_code = IPMI_CC_CANT_RET_NUM_REQ_BYTES;
         return;
     }

--- a/modules/ipmb.c
+++ b/modules/ipmb.c
@@ -184,7 +184,7 @@ void IPMB_RXTask ( void *pvParameters )
 
     for ( ;; ) {
         /* Checks if there's any incoming messages (the task remains blocked here) */
-        rx_len = xI2CSlaveReceive( IPMB_I2C, &ipmb_buffer_rx[1], (sizeof(ipmb_buffer_rx)/sizeof(ipmb_buffer_rx[0])), portMAX_DELAY );
+        rx_len = xI2CSlaveReceive( IPMB_I2C, &ipmb_buffer_rx[1], IPMI_MSG_MAX_LENGTH - 1, portMAX_DELAY );
 
         if ( rx_len > 0 ) {
 


### PR DESCRIPTION
This change intends to fix 2 size checks:
- In the IPMB RX task, the I2C receive function doesn't consider the address, but the IPMI message does. The commit fixing it was provided by Tomasz.
- In the IPMI read FRU data handler, the check on the reply maximum size was ignoring header, count and checksum.