### PR TITLE
Remove BENCH_TEST macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,11 +70,6 @@ include_directories( ${UCONTROLLER_HDRS} ${PROJ_HDRS} )
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DTARGET_CONTROLLER=${TARGET_CONTROLLER} -DTARGET_BOARD_NAME=\"${TARGET_BOARD_NAME}\" ")
 
-if(BENCH_TEST)
-  set(MODULES_FLAGS "${MODULES_FLAGS} -DBENCH_TEST")
-  message( STATUS "${Magenta}Bench mode activated! ${ColourReset}")
-endif()
-
 # Get Git information
 git_describe(GIT_TAG "--tags")
 get_git_head_revision(GIT_REFSPEC GIT_SHA1)

--- a/modules/ipmb.h
+++ b/modules/ipmb.h
@@ -38,6 +38,11 @@
 
 
 /**
+ * @brief Address out of range of the MicroTCA Carrier's AMC Slot ID
+ */
+#define IPMB_ADDR_DISCONNECTED	0xA2
+
+/**
  * @brief Maximum count of messages to be sent
  */
 #define IPMB_TXQUEUE_LEN        10

--- a/modules/main.c
+++ b/modules/main.c
@@ -64,10 +64,6 @@ int main( void )
     printf("Version: %s\n", g_GIT_TAG);
     printf("SHA1: %s\n", g_GIT_SHA1);
 
-#ifdef BENCH_TEST
-    printf("BENCH_TEST mode activated! This will enable some debug functions, be careful!\n");
-#endif
-
 #ifdef MODULE_WATCHDOG
     watchdog_init();
 #endif

--- a/port/board/afc-bpm/v3_1/payload.c
+++ b/port/board/afc-bpm/v3_1/payload.c
@@ -178,11 +178,17 @@ TaskHandle_t vTaskPayload_Handle;
 
 void payload_init( void )
 {
+    /* Set standalone mode if the module is disconnected from a create*/
+    bool standalone_mode = false;
 
-#ifndef BENCH_TEST
-    /* Wait until ENABLE# signal is asserted ( ENABLE == 0) */
-    while ( gpio_read_pin( PIN_PORT(GPIO_MMC_ENABLE), PIN_NUMBER(GPIO_MMC_ENABLE) ) == 1 ) {};
-#endif
+    if (get_ipmb_addr() == IPMB_ADDR_DISCONNECTED) {
+        standalone_mode = true;
+    }
+
+    if (!standalone_mode) {
+        /* Wait until ENABLE# signal is asserted ( ENABLE == 0) */
+        while ( gpio_read_pin( PIN_PORT(GPIO_MMC_ENABLE), PIN_NUMBER(GPIO_MMC_ENABLE) ) == 1 ) {};
+    }
 
     xTaskCreate( vTaskPayload, "Payload", 120, NULL, tskPAYLOAD_PRIORITY, &vTaskPayload_Handle );
 

--- a/port/board/afc-timing/payload.c
+++ b/port/board/afc-timing/payload.c
@@ -179,10 +179,19 @@ TaskHandle_t vTaskPayload_Handle;
 void payload_init( void )
 {
 
-#ifndef BENCH_TEST
-    /* Wait until ENABLE# signal is asserted ( ENABLE == 0) */
-    while ( gpio_read_pin( PIN_PORT(GPIO_MMC_ENABLE), PIN_NUMBER(GPIO_MMC_ENABLE) ) == 1 ) {};
-#endif
+
+    /* Set standalone mode if the module is disconnected from a create*/
+    bool standalone_mode = false;
+
+    if (get_ipmp_addr() == IPMB_ADDR_DISCONNECTED) {
+        standalone_mode = true;
+    }
+
+    if (!standalone_mode) {
+        /* Wait until ENABLE# signal is asserted ( ENABLE == 0) */
+        while ( gpio_read_pin( PIN_PORT(GPIO_MMC_ENABLE), PIN_NUMBER(GPIO_MMC_ENABLE) ) == 1 ) {};
+    }
+
 
     xTaskCreate( vTaskPayload, "Payload", 120, NULL, tskPAYLOAD_PRIORITY, &vTaskPayload_Handle );
 

--- a/port/board/afc-v4/payload.c
+++ b/port/board/afc-v4/payload.c
@@ -224,7 +224,7 @@ void payload_init( void )
     bool standalone_mode = false;
     mmc_err err;
 
-    if (get_ipmb_addr() == 0xA2) {
+    if (get_ipmb_addr() == IPMB_ADDR_DISCONNECTED) {
         standalone_mode = true;
     }
 


### PR DESCRIPTION
Remove the BENCH_TEST macro by checking if the IPMB pins are unconnected and setting the standalone mode. Resolve #133.