### PR TITLE
fix cold_reset bug

### DIFF
--- a/port/board/afc-bpm/v3_1/payload.c
+++ b/port/board/afc-bpm/v3_1/payload.c
@@ -234,12 +234,27 @@ void vTaskPayload( void *pvParameters )
         current_evt = xEventGroupGetBits( amc_payload_evt );
 
         if ( current_evt & PAYLOAD_MESSAGE_QUIESCE ) {
-            QUIESCED_req = 1;
+        
+            /*
+             * If you issue a shutdown fru command in the MCH shell, the payload power 
+             * task will receive a PAYLOAD_MESSAGE_QUIESCE message and set the 
+             * QUIESCED_req flag to '1' and the MCH will shutdown the 12VP0 power, 
+             * making the payload power task go to PAYLOAD_NO_POWER state. 
+             * So, if we are in the PAYLOAD_QUIESCED state and receive a
+             * PAYLOAD_MESSAGE_QUIESCE message, the QUIESCED_req flag 
+             * should be '0'
+             */
+    
+            if (state == PAYLOAD_QUIESCED) {
+	        QUIESCED_req = 0;
+	    } else {
+	        QUIESCED_req = 1;
+	    }
             xEventGroupClearBits( amc_payload_evt, PAYLOAD_MESSAGE_QUIESCE );
         }
 
         if ( current_evt & PAYLOAD_MESSAGE_COLD_RST ) {
-            state = PAYLOAD_SWITCHING_OFF;
+            state = PAYLOAD_RESET;
             xEventGroupClearBits( amc_payload_evt, PAYLOAD_MESSAGE_COLD_RST );
         }
 
@@ -306,6 +321,12 @@ void vTaskPayload( void *pvParameters )
             if (PP_good == 0 && DCDC_good == 0) {
                 new_state = PAYLOAD_NO_POWER;
             }
+            break;
+        
+        case PAYLOAD_RESET:
+            /*Reset DCDC converters*/
+            setDC_DC_ConvertersON( false );
+            new_state = PAYLOAD_NO_POWER;
             break;
 
         default:

--- a/port/board/afc-bpm/v3_1/payload.h
+++ b/port/board/afc-bpm/v3_1/payload.h
@@ -48,6 +48,7 @@ extern enum {
     PAYLOAD_FPGA_ON,
     PAYLOAD_SWITCHING_OFF,
     PAYLOAD_QUIESCED,
+    PAYLOAD_RESET,
     PAYLOAD_MAX_STATES
 } payload_state;
 

--- a/port/board/afc-timing/payload.c
+++ b/port/board/afc-timing/payload.c
@@ -234,12 +234,27 @@ void vTaskPayload( void *pvParameters )
         current_evt = xEventGroupGetBits( amc_payload_evt );
 
         if ( current_evt & PAYLOAD_MESSAGE_QUIESCE ) {
-            QUIESCED_req = 1;
+	    
+            /*
+             * If you issue a shutdown fru command in the MCH shell, the payload power 
+             * task will receive a PAYLOAD_MESSAGE_QUIESCE message and set the 
+             * QUIESCED_req flag to '1' and the MCH will shutdown the 12VP0 power, 
+             * making the payload power task go to PAYLOAD_NO_POWER state. 
+             * So, if we are in the PAYLOAD_QUIESCED state and receive a
+             * PAYLOAD_MESSAGE_QUIESCE message, the QUIESCED_req flag 
+             * should be '0'
+             */
+    
+            if (state == PAYLOAD_QUIESCED) {
+	        QUIESCED_req = 0;
+	    } else {
+	        QUIESCED_req = 1;
+	    }
             xEventGroupClearBits( amc_payload_evt, PAYLOAD_MESSAGE_QUIESCE );
         }
 
         if ( current_evt & PAYLOAD_MESSAGE_COLD_RST ) {
-            state = PAYLOAD_SWITCHING_OFF;
+            state = PAYLOAD_RESET;
             xEventGroupClearBits( amc_payload_evt, PAYLOAD_MESSAGE_COLD_RST );
         }
 
@@ -306,6 +321,11 @@ void vTaskPayload( void *pvParameters )
             if (PP_good == 0 && DCDC_good == 0) {
                 new_state = PAYLOAD_NO_POWER;
             }
+            break;
+        case PAYLOAD_RESET:
+            /*Reset DCDC converters*/
+            setDC_DC_ConvertersON( false );
+            new_state = PAYLOAD_NO_POWER;
             break;
 
         default:

--- a/port/board/afc-timing/payload.h
+++ b/port/board/afc-timing/payload.h
@@ -48,6 +48,7 @@ extern enum {
     PAYLOAD_FPGA_ON,
     PAYLOAD_SWITCHING_OFF,
     PAYLOAD_QUIESCED,
+    PAYLOAD_RESET,
     PAYLOAD_MAX_STATES
 } payload_state;
 

--- a/port/board/afc-v4/payload.c
+++ b/port/board/afc-v4/payload.c
@@ -330,12 +330,27 @@ void vTaskPayload( void *pvParameters )
         current_evt = xEventGroupGetBits( amc_payload_evt );
 
         if ( current_evt & PAYLOAD_MESSAGE_QUIESCE ) {
-            QUIESCED_req = 1;
+            
+            /*
+             * If you issue a shutdown fru command in the MCH shell, the payload power 
+             * task will receive a PAYLOAD_MESSAGE_QUIESCE message and set the 
+             * QUIESCED_req flag to '1' and the MCH will shutdown the 12VP0 power, 
+             * making the payload power task go to PAYLOAD_NO_POWER state. 
+             * So, if we are in the PAYLOAD_QUIESCED state and receive a
+             * PAYLOAD_MESSAGE_QUIESCE message, the QUIESCED_req flag 
+             * should be '0'
+             */
+    
+            if (state == PAYLOAD_QUIESCED) {
+	        QUIESCED_req = 0;
+	    } else {
+	        QUIESCED_req = 1;
+	    }
             xEventGroupClearBits( amc_payload_evt, PAYLOAD_MESSAGE_QUIESCE );
         }
 
         if ( current_evt & PAYLOAD_MESSAGE_COLD_RST ) {
-            state = PAYLOAD_SWITCHING_OFF;
+            state = PAYLOAD_RESET;
             xEventGroupClearBits( amc_payload_evt, PAYLOAD_MESSAGE_COLD_RST );
         }
 
@@ -418,6 +433,12 @@ void vTaskPayload( void *pvParameters )
             if (PP_good == 0 && DCDC_good == 0) {
                 new_state = PAYLOAD_NO_POWER;
             }
+            break;
+
+        case PAYLOAD_RESET:
+            /*Reset DCDC converters*/
+            setDC_DC_ConvertersON( false );
+            new_state = PAYLOAD_NO_POWER;
             break;
 
         default:

--- a/port/board/afc-v4/payload.h
+++ b/port/board/afc-v4/payload.h
@@ -49,7 +49,8 @@ extern enum {
     PAYLOAD_FPGA_ON,
     PAYLOAD_SWITCHING_OFF,
     PAYLOAD_QUIESCED,
-    PAYLOAD_MAX_STATES
+    PAYLOAD_RESET,
+    PAYLOAD_MAX_STATES,
 } payload_state;
 
 /**


### PR DESCRIPTION
Fix cold_reset issue #130 by creating a new state, `PAYLOAD_RESET`, that reset the DCDC converter. Also keeps the `QUIESCED_req` flag equals 0 when `state == PAYLOAD_QUIESCED` and receives an `PAYLOAD_MESSAGE_QUIESCE` message.