### PR TITLE
Correct typo on get_ipmb_addr function

### DIFF
--- a/port/board/afc-timing/payload.c
+++ b/port/board/afc-timing/payload.c
@@ -183,7 +183,7 @@ void payload_init( void )
     /* Set standalone mode if the module is disconnected from a create*/
     bool standalone_mode = false;
 
-    if (get_ipmp_addr() == IPMB_ADDR_DISCONNECTED) {
+    if (get_ipmb_addr() == IPMB_ADDR_DISCONNECTED) {
         standalone_mode = true;
     }
 


### PR DESCRIPTION
The typo when calling the function get_ipmb_addr doesn't allow to compile to afc timing board. Fixed.