### PR TITLE
Add support to Digilent's JTAG HS3 probe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
           - { flags: -DBOARD=afc-bpm -DVERSION=3.1 } 
           - { flags: -DBOARD=afc-timing -DBOARD_RTM=8sfp }
           - { flags: -DBOARD=afc-v4 }
+          - { flags: -DBOARD=afc-v4 -DDEBUG_PROBE=jlink -DOPENOCD_TRANSPORT=swd }
+          - { flags: -DBOARD=afc-v4 -DDEBUG_PROBE=cmsis-dap -DOPENOCD_TRANSPORT=swd }
+          - { flags: -DBOARD=afc-v4 -DDEBUG_PROBE=digilent_jtag_hs3 -DOPENOCD_TRANSPORT=jtag }
     steps:
       - uses: actions/checkout@v3
         with:
@@ -25,7 +28,7 @@ jobs:
         run: mkdir build
       - name: Configure CMake
         working-directory: build
-        run: cmake .. -DDEBUG_PROBE=jlink -DCMAKE_BUILD_TYPE=RELWITHDEBINFO ${{matrix.build-flags.flags}}
+        run: cmake .. -DCMAKE_BUILD_TYPE=RELWITHDEBINFO ${{matrix.build-flags.flags}}
       - name: Build for all targets
         working-directory: build
         run: make

--- a/probe/openocd.cfg.in
+++ b/probe/openocd.cfg.in
@@ -1,4 +1,4 @@
-source [find interface/${DEBUG_PROBE}.cfg]
+source [find ${OPENOCD_DEBUG_PROBE_FILE}]
 
 transport select ${OPENOCD_TRANSPORT}
 

--- a/probe/openocd.cmake
+++ b/probe/openocd.cmake
@@ -1,53 +1,80 @@
 ##Program command
 
+function(check_probe_transport transport_list selected_transport)
+  set(transport_available FALSE)
+  foreach(transport IN LISTS transport_list)
+    if(${selected_transport} STREQUAL ${transport})
+      set(transport_available TRUE)
+    endif()
+  endforeach()
+  if(NOT transport_available)
+    message(FATAL_ERROR "Debug probe does not support transport type '${selected_transport}'")
+  endif()
+endfunction()
+
 if(NOT DEBUG_PROBE)
-  set(DEBUG_PROBE "cmsis-dap")
-endif()
-
-if(NOT OPENOCD_TRANSPORT)
-  set(OPENOCD_TRANSPORT "swd")
-endif()
-
-if(${DEBUG_PROBE} STREQUAL "cmsis-dap")
-elseif(${DEBUG_PROBE} STREQUAL "jlink")
+  message(NOTICE "No debug probe selected! Targets program_boot, program_app and program_all will not be generated!")
 else()
-  message(FATAL_ERROR "${DEBUG_PROBE} not supported!")
+
+  if(NOT OPENOCD_TRANSPORT)
+    message(NOTICE "No debug probe transport set, 'jtag' selected by default.")
+    set(OPENOCD_TRANSPORT "jtag")
+  endif()
+
+  # Selects the OpenOCD debug probe file
+  if(${DEBUG_PROBE} STREQUAL "digilent_jtag_hs3")
+    set(OPENOCD_DEBUG_PROBE_FILE "interface/ftdi/digilent_jtag_hs3.cfg")
+    check_probe_transport("jtag" ${OPENOCD_TRANSPORT})
+  elseif(${DEBUG_PROBE} STREQUAL "cmsis-dap")
+    set(OPENOCD_DEBUG_PROBE_FILE "interface/cmsis-dap.cfg")
+    check_probe_transport("jtag;swd" ${OPENOCD_TRANSPORT})
+  elseif(${DEBUG_PROBE} STREQUAL "jlink")
+    set(OPENOCD_DEBUG_PROBE_FILE "interface/jlink.cfg")
+    check_probe_transport("jtag;swd" ${OPENOCD_TRANSPORT})
+  else()
+    message(FATAL_ERROR "${DEBUG_PROBE} not supported!")
+  endif()
+
+  message(STATUS "Selected debug probe: ${DEBUG_PROBE}")
+
+  if(${TARGET_CONTROLLER} MATCHES "^([lL][pP][cC]17[0-9][0-9])")
+    set(OPENOCD_TARGET lpc17xx)
+  else()
+    message(FATAL_ERROR "Target ${TARGET_CONTROLLER} not supported")
+  endif()
+
+  configure_file(probe/openocd.cfg.in ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openocd.cfg)
+
+  # FIXME: The program_* targets hardcodes the program memory
+  # addresses for the application and bootloader. This might be
+  # different for other microcontrollers. Ideally, OpenOCD should use
+  # the ELF files to program those, but from my tests, it doesn't work
+  # because OpenOCD erases all flash before writing the binary from
+  # the ELF file.
+  add_custom_target(program_boot
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
+    DEPENDS newboot
+    #Write bootloader firmware
+    COMMAND openocd -f openocd.cfg -c "init" -c "program newboot.bin 0x0000 verify" -c "reset run" -c "shutdown"
+  )
+
+  add_custom_target(program_app
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
+    DEPENDS ${CMAKE_PROJECT_NAME}
+    #Write application firmware
+    COMMAND openocd -f openocd.cfg -c "init" -c "program ${CMAKE_PROJECT_NAME}.bin 0x2000 verify" -c "reset run" -c "shutdown"
+  )
+
+  add_custom_target(program_all
+    WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
+    DEPENDS ${CMAKE_PROJECT_NAME} newboot
+    #Erase all flash
+    COMMAND openocd -f openocd.cfg -c "init" -c "halt" -c "flash erase_sector 0 0 last" -c "flash erase_check 0" -c "shutdown"
+    #Write application and bootloader firmwares
+    COMMAND make -C ${CMAKE_BINARY_DIR} program_boot
+    COMMAND make -C ${CMAKE_BINARY_DIR} program_app
+  )
 endif()
-
-message(STATUS "Selected debug probe: ${DEBUG_PROBE}")
-
-if(${TARGET_CONTROLLER} MATCHES "^([lL][pP][cC]17[0-9][0-9])")
-  set(OPENOCD_TARGET lpc17xx)
-else()
-  message(FATAL_ERROR "Target ${TARGET_CONTROLLER} not supported")
-endif()
-
-configure_file(probe/openocd.cfg.in ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/openocd.cfg)
-
-# Program the chip (available only for LPC1764 so far)
-add_custom_target(program_boot
-  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
-  DEPENDS newboot
-  #Write bootloader firmware
-  COMMAND openocd -f openocd.cfg -c "init" -c "program newboot.bin 0x0000 verify" -c "reset run" -c "shutdown"
-  )
-
-add_custom_target(program_app
-  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
-  DEPENDS ${CMAKE_PROJECT_NAME}
-  #Write application firmware
-  COMMAND openocd -f openocd.cfg -c "init" -c "program ${CMAKE_PROJECT_NAME}.bin 0x2000 verify" -c "reset run" -c "shutdown"
-  )
-
-add_custom_target(program_all
-  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/
-  DEPENDS ${CMAKE_PROJECT_NAME} newboot
-  #Erase all flash
-  COMMAND openocd -f openocd.cfg -c "init" -c "halt" -c "flash erase_sector 0 0 last" -c "flash erase_check 0" -c "shutdown"
-  #Write application and bootloader firmwares
-  COMMAND make -C ${CMAKE_BINARY_DIR} program_boot
-  COMMAND make -C ${CMAKE_BINARY_DIR} program_app
-  )
 
 add_custom_target(full_binary
   WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/


### PR DESCRIPTION
Also improve debug probe handling, if DEBUG_PROBE is not set during configuration, targets program_boot, program_app and program_all will not be generated.