### PR TITLE
Fix the real size of tx_len

### DIFF
--- a/modules/at24mac.c
+++ b/modules/at24mac.c
@@ -106,6 +106,7 @@ size_t at24mac_write( uint8_t id, uint16_t address, uint8_t *tx_data, size_t buf
 
             /* Write the data */
             tx_len += xI2CMasterWrite( i2c_interface, i2c_addr, &page_buf[0] , bytes_to_write+1 );
+            tx_len -= 1; /* Remove byte address from data written size */
             curr_addr += bytes_to_write;
         }
         i2c_give( i2c_interface );


### PR DESCRIPTION
Since the first byte of page_buf is the address, the real written data is the number of written bytes minus one.