### PR TITLE
Move the count check to be done after the fru_write call

### DIFF
--- a/modules/fru.c
+++ b/modules/fru.c
@@ -334,6 +334,15 @@ IPMI_HANDLER(ipmi_storage_write_fru_data_cmd, NETFN_STORAGE, IPMI_WRITE_FRU_DATA
         /* Write data to the FRU */
         count = fru_write( id, &req->data[3], offset, req->data_len - 3);
 
+        /*
+         * If count == 0, it may indicate that the fru_write function
+         *  failed somehow.
+         */
+
+        if (count == 0) {
+            rsp->completion_code = IPMI_CC_UNSPECIFIED_ERROR;
+            return ;
+        }
         /* Count written (1 based) */
         rsp->data[len++] = count +1;
     } else {
@@ -342,14 +351,5 @@ IPMI_HANDLER(ipmi_storage_write_fru_data_cmd, NETFN_STORAGE, IPMI_WRITE_FRU_DATA
         rsp->completion_code = IPMI_CC_PARAM_OUT_OF_RANGE;
     }
 
-    /*
-     *  If count == 0, it may indicate that the fru_write function
-     *  failed somehow.
-     */
-
-    if (count == 0) {
-        rsp->completion_code = IPMI_CC_UNSPECIFIED_ERROR;
-        return ;
-    }
     rsp->data_len = len;
 }


### PR DESCRIPTION
Since we are checking how many chars was writen and using this as diagnostics for the fru_write call, the count check must be made only if the function is called. In this way, the check must be in the same condition as the function call.