### PR TITLE
Change the TARGET_BOARD_NAME from AFC Timing to AFC v3.1

### DIFF
--- a/port/board/afc-v3/CMakeLists.txt
+++ b/port/board/afc-v3/CMakeLists.txt
@@ -4,7 +4,7 @@ if (NOT TARGET_CONTROLLER)
 endif()
 
 if (NOT TARGET_BOARD_NAME)
-  set(TARGET_BOARD_NAME "AFC Timing" CACHE STRING "Board Name")
+  set(TARGET_BOARD_NAME "AFC v3.1" CACHE STRING "Board Name")
 endif()
 
 #List all modules used by this board

--- a/port/board/afc-v4/CMakeLists.txt
+++ b/port/board/afc-v4/CMakeLists.txt
@@ -4,7 +4,7 @@ if (NOT TARGET_CONTROLLER)
 endif()
 
 if (NOT TARGET_BOARD_NAME)
-  set(TARGET_BOARD_NAME "AFC v4" CACHE STRING "Board Name")
+  set(TARGET_BOARD_NAME "AFC v4.0" CACHE STRING "Board Name")
 endif()
 
 #List all modules used by this board


### PR DESCRIPTION
Since the merge of afc-bpm and afc-timing in afc v3.1, there's no long needed to specify the target board. Also, standardize the afc v4.0 field.