### PR TITLE
Fix RTM disable payload power error check

### DIFF
--- a/modules/rtm.c
+++ b/modules/rtm.c
@@ -24,6 +24,7 @@
 #include "event_groups.h"
 
 /* Project includes */
+#include "mmc_error.h"
 #include "port.h"
 #include "rtm.h"
 #include "rtm_user.h"
@@ -127,7 +128,7 @@ void RTM_Manage( void * Parameters )
         current_evt = xEventGroupGetBits( rtm_payload_evt );
 
         if ( current_evt & PAYLOAD_MESSAGE_QUIESCE ) {
-            if ( rtm_disable_payload_power() ) {
+            if (rtm_disable_payload_power() == MMC_OK) {
                 /* Quiesced event */
                 printf("[RTM] Quiesced RTM successfuly!\n");
                 hotswap_set_mask_bit( HOTSWAP_RTM, HOTSWAP_QUIESCED_MASK );


### PR DESCRIPTION
Commit 331bb6fea7173a9abdd14f22d4a834b3253bc334 replaced the rtm_quiesce() function with rtm_disable_payload_power(), but the last returns the mmc_err enum type, so it should be compared with the enum values.

MMC_OK is the first value defined in the mmc_err enum type, so it was represented numerically as 0, and would evaluate as false in the if statement.