### PR TITLE
Workaround payload loss of power due a voltage dip in the 12V power rail [AFCv4.0]

### DIFF
--- a/port/board/afc-v4/payload.c
+++ b/port/board/afc-v4/payload.c
@@ -411,6 +411,7 @@ void vTaskPayload( void *pvParameters )
 
         case PAYLOAD_FPGA_ON:
             if ( QUIESCED_req == 1 || PP_good == 0 || DCDC_good == 0 ) {
+                printf("QUIESCED_req = %d, PP_good = %d, DCDC_good = %d\n", QUIESCED_req, PP_good, DCDC_good);
                 new_state = PAYLOAD_SWITCHING_OFF;
             }
             break;


### PR DESCRIPTION
We observed that a specific AFCv4.0 card suffers a loss of power in the payload power rails event though the MCH indicates that the card is in M4 state. It seems that the MMC detects a voltage dip in the 12V power rail and turns off the DC/DC converters, but we suspect it is a false reading.